### PR TITLE
Fix JSON key formatting to support spaces and special characters

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,14 +6,14 @@
 * @example:  var obj = {"foo":"bar"};  obj.prettyPrint();
 */
 window.prettyPrint = function (json) {
-    var jsonLine = /^( *)("[\w]+": )?("[^"]*"|[\w.+-]*|\[\])?([,[{])?$/mg;
-    var replacer = function (match, pIndent, pKey, pVal, pEnd) {
+    var jsonLine = /^( *)("([^"\\]|\\.)*": )?("[^"]*"|[\w.+-]*|\[\])?([,[{])?$/mg;
+    var replacer = function (match, pIndent, pKey, pKeyContent, pVal, pEnd) {
         var key = '<span class="json-key" style="color: brown">',
             val = '<span class="json-value" style="color: navy">',
             str = '<span class="json-string" style="color: olive">',
             r = pIndent || '';
         if (pKey)
-            r = r + key + pKey.replace(/[": ]/g, '') + '</span>: ';
+            r = r + key + pKey.replace(/^"|": $/g, '') + '</span>: ';
         if (pVal)
             r = r + (pVal[0] == '"' ? str : val) + pVal + '</span>';
         return r + (pEnd || '');


### PR DESCRIPTION
Updated the JSON pretty-printing regex and key processing to properly handle JSON keys containing spaces, special characters, and escaped sequences.

Regex changes:
- jsonLine pattern: Changed "[\w]+" to "([^"\\]|\\.)*"
  * Old: "[\w]+" only matched word characters (a-z, A-Z, 0-9, _)
  * New: "([^"\\]|\\.)*" matches any character except quotes/backslashes, plus escaped sequences, allowing spaces and special characters in keys
  * Added capture group creates pKeyContent parameter in replacer function

Key processing changes:
- pKey.replace(): Changed /[": ]/g to /^"|": $/g
  * Old: /[": ]/g stripped all quotes, colons, and spaces from anywhere in key
  * New: /^"|": $/g only removes opening quote and trailing quote+colon
  * Preserves internal spaces in key names (e.g., "Case Information" → Case Information)

This resolves formatting issues where JSON keys with spaces would break the syntax highlighting and cause display corruption in the pretty-printed output.